### PR TITLE
Adding API options to `findById`

### DIFF
--- a/src/wiki.js
+++ b/src/wiki.js
@@ -123,7 +123,10 @@ export default function wiki(options = {}) {
 	 */
 	function findById(pageid) {
 		return api(apiOptions, {
-			pageids: pageid
+				prop: 'info|pageprops',
+				inprop: 'url',
+				ppprop: 'disambiguation',
+				pageids: pageid
 			})
 		.then(handleRedirect)
 			.then(res => {

--- a/test/spec.js
+++ b/test/spec.js
@@ -104,7 +104,7 @@ describe('Wiki Methods', () => {
 
 	it('Should find page by given id', () => {
 		nock('http://en.wikipedia.org')
-			.get('/w/api.php?pageids=4335&format=json&action=query&redirects=&origin=*')
+			.get('/w/api.php?prop=info%7Cpageprops&inprop=url&ppprop=disambiguation&pageids=4335&format=json&action=query&redirects=&origin=*')
 			.once()
 			.reply(200, JSON.parse(fs.readFileSync('./test/data/1463865884408.json')));
 


### PR DESCRIPTION
The function `findById` did not return the same object like `page`. The API options must be the same for consistency.

Before:
```
{ raw: { pageid: 68187, ns: 0, title: 'FC Barcelona' },
  html: [Function: html],
  content: [Function: content],
  summary: [Function: summary],
  images: [Function: images],
  references: [Function: references],
  links: [Function: links],
  categories: [Function: categories],
  coordinates: [Function: coordinates],
  info: [Function: q],
  backlinks: [Function: backlinks],
  rawImages: [Function: h],
  mainImage: [Function: mainImage],
  langlinks: [Function: langlinks],
  rawInfo: [Function: p] }
```

After:

```
{ raw: 
   { pageid: 68187,
     ns: 0,
     title: 'FC Barcelona',
     contentmodel: 'wikitext',
     pagelanguage: 'en',
     pagelanguagehtmlcode: 'en',
     pagelanguagedir: 'ltr',
     touched: '2017-10-10T06:06:26Z',
     lastrevid: 803940480,
     length: 150109,
     fullurl: 'https://en.wikipedia.org/wiki/FC_Barcelona',
     editurl: 'https://en.wikipedia.org/w/index.php?title=FC_Barcelona&action=edit',
     canonicalurl: 'https://en.wikipedia.org/wiki/FC_Barcelona' },
  html: [Function: html],
  content: [Function: content],
  summary: [Function: summary],
  images: [Function: images],
  references: [Function: references],
  links: [Function: links],
  categories: [Function: categories],
  coordinates: [Function: coordinates],
  info: [Function: q],
  backlinks: [Function: backlinks],
  rawImages: [Function: h],
  mainImage: [Function: mainImage],
  langlinks: [Function: langlinks],
  rawInfo: [Function: p] }
```

