### PR TITLE
Update findById examples to use ids

### DIFF
--- a/docs/wikijs/4.3.0/Wiki.html
+++ b/docs/wikijs/4.3.0/Wiki.html
@@ -281,7 +281,7 @@
 <div class="section-examples">
 <h5>Example</h5>
 
-    <pre class="prettyprint"><code>wiki.findById('Batman').then(page => console.log(page.title));</code></pre>
+    <pre class="prettyprint"><code>wiki.findById(4335).then(page => console.log(page.title));</code></pre>
 
 </div>
 

--- a/docs/wikijs/4.3.0/wiki.js.html
+++ b/docs/wikijs/4.3.0/wiki.js.html
@@ -157,7 +157,7 @@ export default function wiki(options = {}) {
 	/**
 	 * Get Page by PageId
 	 * @example
-	 * wiki.findById('Batman').then(page => console.log(page.title));
+	 * wiki.findById(4335).then(page => console.log(page.title));
 	 * @method Wiki#findById
 	 * @param {integer} pageid, id of the page
 	 * @return {Promise}

--- a/src/wiki.js
+++ b/src/wiki.js
@@ -116,7 +116,7 @@ export default function wiki(options = {}) {
 	/**
 	 * Get Page by PageId
 	 * @example
-	 * wiki.findById('Batman').then(page => console.log(page.title));
+	 * wiki.findById(4335).then(page => console.log(page.title));
 	 * @method Wiki#findById
 	 * @param {integer} pageid, id of the page
 	 * @return {Promise}


### PR DESCRIPTION
The examples using a string were wrong and confused me a bit.