### PR TITLE
fixes article section headers regex (thanks to Wiktor Stribiżew from SO)

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -87,7 +87,7 @@ export function aggregate(apiOptions, params, list, key, prefix, results = []) {
 	});
 }
 
-const headingPattern = /(=+)\s?([\w\s-]+)\s?=+/g;
+const headingPattern = /(==+)((?!\n)\s?)(((?!==|\n)[^])+)((?!\n)\s?)(==+)/g;
 
 function getHeadings(text) {
 	let match;


### PR DESCRIPTION
I fixed the regex pattern for parsing article section headers [with the help of Wiktor Stribiżew](https://stackoverflow.com/q/55045056/3424416#comment96841066_55045056).

Previously it could not parse headings with various special characters such as commas etc.  
Newlines are excluded because these break the wiki syntax for section headers.

The documentation should also feature a short demo on how to get/use the sections. Didn't add any as there's no folder for v5.0 yet.

I use it basically like this: 
```
wiki({ apiUrl: 'https://en.wikipedia.org/w/api.php' })
    .page('Batman')
    .then(page => page.content())
    .then(content => {
      let sections = []
      content
        .filter(c => {
          return c.title.toLowerCase().includes('history')
        })
        .forEach(s => sections.push(s))
      console.log(sections)
    })
```

The section parsing needs to be improved further so that you can easily specify e.g. the parent-section and the level(s) of sections you're interested in. I would suggest to not delete section.level etc. in parseContent.

Also this doesn't yet check for `<code>` as can be found in the article "[Relational operator](https://en.wikipedia.org/wiki/Relational_operator)".