### PR TITLE
fix title parsing in getHeadings

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -87,7 +87,7 @@ export function aggregate(apiOptions, params, list, key, prefix, results = []) {
 	});
 }
 
-const headingPattern = /(==+)((?!\n)\s?)(((?!==|\n)[^])+)((?!\n)\s?)(==+)/g;
+const headingPattern = /(==+)(?:(?!\n)\s?)((?:(?!==|\n)[^])+)(?:(?!\n)\s?)(==+)/g;
 
 function getHeadings(text) {
 	let match;

--- a/test/data/content.txt
+++ b/test/data/content.txt
@@ -1,0 +1,14 @@
+summary
+
+
+== section 1 ==
+
+content 1
+
+
+== section 2 (empty) ==
+
+
+== section 3 ==
+
+content 3

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,18 @@
+import 'should';
+import { parseContent } from '../src/util';
+import fs from 'fs';
+
+describe('parseContent', () => {
+  it('should parse input text properly', function(done) {
+    const content = parseContent(
+      fs.readFileSync('./test/data/content.txt').toString()
+    );
+    content.should.deepEqual([
+      { title: 'section 1', content: 'content 1' },
+      { title: 'section 2 (empty)', content: '' },
+      { title: 'section 3', content: 'content 3' }
+    ]);
+
+    done();
+  });
+});


### PR DESCRIPTION
Currently,  `content` method returns blank titles. This change will fix the issue.