### PR TITLE
Adds prefixsearch "best match" functionality similar to Wikipedia homepage search

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -286,6 +286,6 @@ declare module 'wikijs' {
 		 * limits the number of results
 		 * @returns {Promise<Result>}
 		 */
-		prefixsearch(query: string, limit?: number): Promise<Result>;
+		prefixSearch(query: string, limit?: number): Promise<Result>;
 	};
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,37 +1,37 @@
 // Definitions by: Balazs Mocsai <https://github.com/mbale>
 
 declare module 'wikijs' {
-    /**
-     * Default Options
-     * 
-     * @interface Options
-     */
+	/**
+	 * Default Options
+	 *
+	 * @interface Options
+	 */
 	interface Options {
-        /**
-        * URL of Wikipedia API
-        * 
-        * @type {string}
-        * @memberof Options
-        */
+		/**
+		 * URL of Wikipedia API
+		 *
+		 * @type {string}
+		 * @memberof Options
+		 */
 		apiUrl?: string;
-        /**
-         * When accessing the API using a cross-domain AJAX request (CORS), set this to the originating domain. 
-         * This must be included in any pre-flight request, and therefore must be part of the request URI (not the POST body). 
-         * This must match one of the origins in the Origin header exactly, so it has to be set to something like https://en.wikipedia.org or https://meta.wikimedia.org. 
-         * If this parameter does not match the Origin header, a 403 response will be returned. 
-         * If this parameter matches the Origin header and the origin is whitelisted, an Access-Control-Allow-Origin header will be set.
-         * 
-         * @type {string}
-         * @memberof Options
-         */
+		/**
+		 * When accessing the API using a cross-domain AJAX request (CORS), set this to the originating domain.
+		 * This must be included in any pre-flight request, and therefore must be part of the request URI (not the POST body).
+		 * This must match one of the origins in the Origin header exactly, so it has to be set to something like https://en.wikipedia.org or https://meta.wikimedia.org.
+		 * If this parameter does not match the Origin header, a 403 response will be returned.
+		 * If this parameter matches the Origin header and the origin is whitelisted, an Access-Control-Allow-Origin header will be set.
+		 *
+		 * @type {string}
+		 * @memberof Options
+		 */
 		origin?: string;
 	}
 
-    /**
-     * Coordinate object
-     * 
-     * @interface Coordinates
-     */
+	/**
+	 * Coordinate object
+	 *
+	 * @interface Coordinates
+	 */
 	interface Coordinates {
 		lat: number;
 		lon: number;
@@ -39,21 +39,21 @@ declare module 'wikijs' {
 		globe: string;
 	}
 
-    /**
-     * Link object { lang, title }
-     * 
-     * @interface Link
-     */
+	/**
+	 * Link object { lang, title }
+	 *
+	 * @interface Link
+	 */
 	interface Link {
 		lang: string;
 		title: string;
 	}
 
-    /**
-     * Image container
-     * 
-     * @interface Image
-     */
+	/**
+	 * Image container
+	 *
+	 * @interface Image
+	 */
 	interface Image {
 		ns: number;
 		title: string;
@@ -66,215 +66,226 @@ declare module 'wikijs' {
 	interface Result {
 		results: string[];
 		query: string;
-		next(): Promise<Result>
+		next(): Promise<Result>;
 	}
-
-    /**
-     * WikiPage
-     * 
-     * @interface Page
-     */
-	interface Page {
-        /**
-         * Paginated backlinks from page
-         * 
-         * @param {boolean} aggregated 
-         * @param {number} limit 
-         * @returns {Promise<string[]>} 
-         * @memberof Page
-         */
-		backlinks(aggregated?: boolean, limit?: number): Promise<string[]>
-
-        /**
-         * Paginated categories from page
-         * 
-         * @param {boolean} aggregated 
-         * @param {number} limit 
-         * @returns {Promise<string[]>} 
-         * @memberof Page
-         */
-		categories(aggregated?: boolean, limit?: number): Promise<string[]>
-
-        /**
-         * Text content from page
-         * 
-         * @returns {Promise<string>} 
-         * @memberof Page
-         */
-		content(): Promise<string>
-
-        /**
-         * Geographical coordinates from page
-         * 
-         * @returns {Promise<Coordinates>} 
-         * @memberof Page
-         */
-		coordinates(): Promise<Coordinates>
-
-		/**
-         * Get full information from page
-         * 
-         * @returns {Promise<object>} 
-         * @memberof Page
-         */
-		fullInfo(): Promise<object>
-
-        /**
-         * HTML from page
-         * 
-         * @returns {Promise<string>} 
-         * @memberof Page
-         */
-		html(): Promise<string>
-
-        /**
-         * Image URL's from page
-         * 
-         * info Object contains key/value pairs of infobox data, or specific value if key given
-         * @returns {Promise<string[]>} 
-         * @memberof Page
-         */
-		images(): Promise<string[]>
-
-        /**
-         * Get information from page
-         * 
-         * @param {string} [key] 
-         * Information key. Falsy keys are ignored
-         * @returns {Promise<object>} 
-         * @memberof Page
-         */
-		info(key?: string): Promise<object>
-
-        /**
-         * Get list of links to different translations
-         * 
-         * @returns {Promise<Link[]>} 
-         * @memberof Page
-         */
-		langlinks(): Promise<Link[]>
-
-        /**
-         * Paginated links from page
-         * 
-         * @param {boolean} [aggregated] 
-         * return all links (default is true)
-         * @param {number} [limit] 
-         * number of links per page
-         * @returns {Promise<string[]>} 
-         * @memberof Page
-         */
-		links(aggregated?: boolean, limit?: number): Promise<string[]>
-
-        /**
-         * Main image URL from infobox on page
-         * 
-         * @returns {Promise<string>} 
-         * @memberof Page
-         */
-		mainImage(): Promise<string>
-
-        /**
-         * Raw data from images from page
-         * 
-         * @returns {Promise<Image[]>} 
-         * @memberof Page
-         */
-		rawImages(): Promise<Image[]>
-
-        /**
-         * References from page
-         * 
-         * @returns {Promise<string[]>} 
-         * @memberof Page
-         */
-		references(): Promise<string[]>
-
-        /**
-         * Text summary from page
-         * 
-         * @returns {Promise<string>} 
-         * @memberof Page
-         */
-		summary(): Promise<string>
-
-		/**
-         * Tables from page
-         * 
-         * @returns {Promise<any>} 
-         * @memberof Page
-         */
-		tables(): Promise<any>
-	}
-
-
-    /**
-     * WikiJs is a node.js library which serves as an interface to Wikipedia (or any MediaWiki).
-     * 
-     * @param {Options} [options] 
-     */
-	export default function WikiJS(options?: Options): {
-        /**
-         * Get Page by PageId
-         * 
-         * @param {string} pageID
-         * id of the page
-         * @returns {Promise<Page>} 
-         */
-		findById(pageID: string): Promise<Page>
-		
 
 	/**
-	 * Find page by query and optional predicate
-	 * @example
-	 * wiki.find('luke skywalker').then(page => console.log(page.title));
-	 * @method Wiki#find
-	 * @param {string} search query
-	 * @param {function} [predicate] - testing function for choosing which page result to fetch. Default is first result.
-	 * @return {Promise}
+	 * WikiPage
+	 *
+	 * @interface Page
 	 */
-		find (query : string, predicate? : (pages : Page[]) => Page) : Promise<Page>;
+	interface Page {
+		/**
+		 * Paginated backlinks from page
+		 *
+		 * @param {boolean} aggregated
+		 * @param {number} limit
+		 * @returns {Promise<string[]>}
+		 * @memberof Page
+		 */
+		backlinks(aggregated?: boolean, limit?: number): Promise<string[]>;
 
-        /**
-         * Geographical Search
-         * 
-         * @param {number} lat
-         * latitude 
-         * @param {number} lon
-         * longitude
-         * @param {number} [radius] 
-         * search radius in kilometers (default: 1km)
-         * @returns {Promise<string[]>}
-         */
-		geoSearch(lat: number, lon: number, radius?: number): Promise<string[]>
+		/**
+		 * Paginated categories from page
+		 *
+		 * @param {boolean} aggregated
+		 * @param {number} limit
+		 * @returns {Promise<string[]>}
+		 * @memberof Page
+		 */
+		categories(aggregated?: boolean, limit?: number): Promise<string[]>;
 
-        /**
-         * Get Page
-         * 
-         * @param {string} title 
-         * title of article
-         * @returns {Promise<Page>} 
-         */
-		page(title: string): Promise<Page>
+		/**
+		 * Text content from page
+		 *
+		 * @returns {Promise<string>}
+		 * @memberof Page
+		 */
+		content(): Promise<string>;
 
-        /**
-         * Random articles
-         * 
-         * @param {number} [limit] 
-         * limits the number of random articles
-         * @returns {Promise<string[]>} 
-         */
-		random(limit?: number): Promise<string[]>
+		/**
+		 * Geographical coordinates from page
+		 *
+		 * @returns {Promise<Coordinates>}
+		 * @memberof Page
+		 */
+		coordinates(): Promise<Coordinates>;
 
-        /**
-         * Search articles
-         * 
-         * @param {string} query
-         * keyword query
-         * @param {number} [limit]
-         * limits the number of results
-         * @returns {Promise<Result>} 
-         */
-		search(query: string, limit?: number): Promise<Result>
+		/**
+		 * Get full information from page
+		 *
+		 * @returns {Promise<object>}
+		 * @memberof Page
+		 */
+		fullInfo(): Promise<object>;
+
+		/**
+		 * HTML from page
+		 *
+		 * @returns {Promise<string>}
+		 * @memberof Page
+		 */
+		html(): Promise<string>;
+
+		/**
+		 * Image URL's from page
+		 *
+		 * info Object contains key/value pairs of infobox data, or specific value if key given
+		 * @returns {Promise<string[]>}
+		 * @memberof Page
+		 */
+		images(): Promise<string[]>;
+
+		/**
+		 * Get information from page
+		 *
+		 * @param {string} [key]
+		 * Information key. Falsy keys are ignored
+		 * @returns {Promise<object>}
+		 * @memberof Page
+		 */
+		info(key?: string): Promise<object>;
+
+		/**
+		 * Get list of links to different translations
+		 *
+		 * @returns {Promise<Link[]>}
+		 * @memberof Page
+		 */
+		langlinks(): Promise<Link[]>;
+
+		/**
+		 * Paginated links from page
+		 *
+		 * @param {boolean} [aggregated]
+		 * return all links (default is true)
+		 * @param {number} [limit]
+		 * number of links per page
+		 * @returns {Promise<string[]>}
+		 * @memberof Page
+		 */
+		links(aggregated?: boolean, limit?: number): Promise<string[]>;
+
+		/**
+		 * Main image URL from infobox on page
+		 *
+		 * @returns {Promise<string>}
+		 * @memberof Page
+		 */
+		mainImage(): Promise<string>;
+
+		/**
+		 * Raw data from images from page
+		 *
+		 * @returns {Promise<Image[]>}
+		 * @memberof Page
+		 */
+		rawImages(): Promise<Image[]>;
+
+		/**
+		 * References from page
+		 *
+		 * @returns {Promise<string[]>}
+		 * @memberof Page
+		 */
+		references(): Promise<string[]>;
+
+		/**
+		 * Text summary from page
+		 *
+		 * @returns {Promise<string>}
+		 * @memberof Page
+		 */
+		summary(): Promise<string>;
+
+		/**
+		 * Tables from page
+		 *
+		 * @returns {Promise<any>}
+		 * @memberof Page
+		 */
+		tables(): Promise<any>;
 	}
+
+	/**
+	 * WikiJs is a node.js library which serves as an interface to Wikipedia (or any MediaWiki).
+	 *
+	 * @param {Options} [options]
+	 */
+	export default function WikiJS(
+		options?: Options
+	): {
+		/**
+		 * Get Page by PageId
+		 *
+		 * @param {string} pageID
+		 * id of the page
+		 * @returns {Promise<Page>}
+		 */
+		findById(pageID: string): Promise<Page>;
+
+		/**
+		 * Find page by query and optional predicate
+		 * @example
+		 * wiki.find('luke skywalker').then(page => console.log(page.title));
+		 * @method Wiki#find
+		 * @param {string} search query
+		 * @param {function} [predicate] - testing function for choosing which page result to fetch. Default is first result.
+		 * @return {Promise}
+		 */
+		find(query: string, predicate?: (pages: Page[]) => Page): Promise<Page>;
+
+		/**
+		 * Geographical Search
+		 *
+		 * @param {number} lat
+		 * latitude
+		 * @param {number} lon
+		 * longitude
+		 * @param {number} [radius]
+		 * search radius in kilometers (default: 1km)
+		 * @returns {Promise<string[]>}
+		 */
+		geoSearch(lat: number, lon: number, radius?: number): Promise<string[]>;
+
+		/**
+		 * Get Page
+		 *
+		 * @param {string} title
+		 * title of article
+		 * @returns {Promise<Page>}
+		 */
+		page(title: string): Promise<Page>;
+
+		/**
+		 * Random articles
+		 *
+		 * @param {number} [limit]
+		 * limits the number of random articles
+		 * @returns {Promise<string[]>}
+		 */
+		random(limit?: number): Promise<string[]>;
+
+		/**
+		 * Search articles
+		 *
+		 * @param {string} query
+		 * keyword query
+		 * @param {number} [limit]
+		 * limits the number of results
+		 * @returns {Promise<Result>}
+		 */
+		search(query: string, limit?: number): Promise<Result>;
+
+		/**
+		 * Search articles using "fuzzy" prefixsearch
+		 *
+		 * @param {string} query
+		 * keyword query
+		 * @param {number} [limit]
+		 * limits the number of results
+		 * @returns {Promise<Result>}
+		 */
+		prefixsearch(query: string, limit?: number): Promise<Result>;
+	};
 }

--- a/src/wiki.js
+++ b/src/wiki.js
@@ -87,17 +87,17 @@ export default function wiki(options = {}) {
 	/**
 	 * Search articles using "fuzzy" prefixsearch
 	 * @example
-	 * wiki.prefixsearch('star wars').then(data => console.log(data.results.length));
+	 * wiki.prefixSearch('star wars').then(data => console.log(data.results.length));
 	 * @example
-	 * wiki.prefixsearch('star wars').then(data => {
+	 * wiki.prefixSearch('star wars').then(data => {
 	 * 	data.next().then(...);
 	 * });
-	 * @method Wiki#prefixsearch
+	 * @method Wiki#prefixSearch
 	 * @param  {string} query - keyword query
 	 * @param  {Number} [limit] - limits the number of results
 	 * @return {Promise} - pagination promise with results and next page function
 	 */
-	function prefixsearch(query, limit = 50) {
+	function prefixSearch(query, limit = 50) {
 		return pagination(
 			apiOptions,
 			{
@@ -273,6 +273,6 @@ export default function wiki(options = {}) {
 		allCategories,
 		pagesInCategory,
 		opensearch,
-		prefixsearch
+		prefixSearch
 	};
 }

--- a/src/wiki.js
+++ b/src/wiki.js
@@ -85,6 +85,32 @@ export default function wiki(options = {}) {
 	}
 
 	/**
+	 * Search articles using "fuzzy" prefixsearch
+	 * @example
+	 * wiki.prefixsearch('star wars').then(data => console.log(data.results.length));
+	 * @example
+	 * wiki.prefixsearch('star wars').then(data => {
+	 * 	data.next().then(...);
+	 * });
+	 * @method Wiki#prefixsearch
+	 * @param  {string} query - keyword query
+	 * @param  {Number} [limit] - limits the number of results
+	 * @return {Promise} - pagination promise with results and next page function
+	 */
+	function prefixsearch(query, limit = 50) {
+		return pagination(
+			apiOptions,
+			{
+				list: 'prefixsearch',
+				pslimit: limit,
+				psprofile: 'fuzzy',
+				pssearch: query
+			},
+			res => res.query.prefixsearch.map(article => article.title)
+		);
+	}
+
+	/**
 	 * Opensearch (mainly used as a backup to normal text search)
 	 * @param  {string} query - keyword query
 	 * @param  {Number} limit - limits the number of results
@@ -246,6 +272,7 @@ export default function wiki(options = {}) {
 		allPages,
 		allCategories,
 		pagesInCategory,
-		opensearch
+		opensearch,
+		prefixsearch
 	};
 }

--- a/test/data/prefixsearch.json
+++ b/test/data/prefixsearch.json
@@ -1,0 +1,144 @@
+{
+  "batchcomplete": "",
+  "continue": {
+    "psoffset": 10,
+    "gpsoffset": 6,
+    "continue": "gpsoffset||"
+  },
+  "query": {
+    "redirects": [
+      {
+        "index": 1,
+        "from": "Mic",
+        "to": "MIC"
+      }
+    ],
+    "pages": {
+      "18859": {
+        "pageid": 18859,
+        "ns": 0,
+        "title": "Michigan",
+        "index": 3,
+        "thumbnail": {
+          "source": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b5/Flag_of_Michigan.svg/80px-Flag_of_Michigan.svg.png",
+          "width": 80,
+          "height": 53
+        },
+        "description": "State of the United States of America",
+        "descriptionsource": "local"
+      },
+      "19001": {
+        "pageid": 19001,
+        "ns": 0,
+        "title": "Microsoft",
+        "index": 4,
+        "thumbnail": {
+          "source": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/Building92microsoft.jpg/80px-Building92microsoft.jpg",
+          "width": 80,
+          "height": 53
+        },
+        "description": "U.S.-headquartered technology company",
+        "descriptionsource": "local"
+      },
+      "20455": {
+        "pageid": 20455,
+        "ns": 0,
+        "title": "Michael Jordan",
+        "index": 6,
+        "thumbnail": {
+          "source": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ae/Michael_Jordan_in_2014.jpg/64px-Michael_Jordan_in_2014.jpg",
+          "width": 64,
+          "height": 80
+        },
+        "description": "American basketball player and businessman",
+        "descriptionsource": "central"
+      },
+      "57187": {
+        "pageid": 57187,
+        "ns": 0,
+        "title": "Mick Jagger",
+        "index": 5,
+        "thumbnail": {
+          "source": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Mick_Jagger_Deauville_2014.jpg/56px-Mick_Jagger_Deauville_2014.jpg",
+          "width": 56,
+          "height": 80
+        },
+        "description": "British songwriter, singer of The Rolling Stones",
+        "descriptionsource": "central"
+      },
+      "118377": {
+        "pageid": 118377,
+        "ns": 0,
+        "title": "MIC",
+        "index": 1,
+        "description": "Disambiguation page providing links to topics that could be referred to by the same search term",
+        "descriptionsource": "local"
+      },
+      "14995351": {
+        "pageid": 14995351,
+        "ns": 0,
+        "title": "Michael Jackson",
+        "index": 2,
+        "thumbnail": {
+          "source": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/Michael_Jackson_signature.svg/80px-Michael_Jackson_signature.svg.png",
+          "width": 80,
+          "height": 79
+        },
+        "description": "American singer, songwriter and dancer",
+        "descriptionsource": "local"
+      }
+    },
+    "prefixsearch": [
+      {
+        "ns": 0,
+        "title": "Mic",
+        "pageid": 300418
+      },
+      {
+        "ns": 0,
+        "title": "Michael Jackson",
+        "pageid": 14995351
+      },
+      {
+        "ns": 0,
+        "title": "Michigan",
+        "pageid": 18859
+      },
+      {
+        "ns": 0,
+        "title": "Microsoft",
+        "pageid": 19001
+      },
+      {
+        "ns": 0,
+        "title": "Mick Jagger",
+        "pageid": 57187
+      },
+      {
+        "ns": 0,
+        "title": "Microsoft Windows",
+        "pageid": 18890
+      },
+      {
+        "ns": 0,
+        "title": "Michael Jordan",
+        "pageid": 20455
+      },
+      {
+        "ns": 0,
+        "title": "Michelangelo",
+        "pageid": 21019
+      },
+      {
+        "ns": 0,
+        "title": "Michael (archangel)",
+        "pageid": 318621
+      },
+      {
+        "ns": 0,
+        "title": "Microsoft Word",
+        "pageid": 20287
+      }
+    ]
+  }
+}

--- a/test/real.js
+++ b/test/real.js
@@ -239,6 +239,14 @@ describe('Live tests', () => {
 				titles.should.have.property('results').containEql('Ashe/Old Lore')
 			);
 	});
+	it('should handle fuzzy prefix searches', function() {
+		this.timeout(timeoutTime);
+		return wiki()
+			.prefixsearch('mic')
+			.then(titles =>
+				titles.should.have.property('results').containEql('Michael Jordan')
+			);
+	});
 	it('should fetch deep infoboxes [Issue #95]', function() {
 		this.timeout(timeoutTime);
 		return wiki()

--- a/test/real.js
+++ b/test/real.js
@@ -242,7 +242,7 @@ describe('Live tests', () => {
 	it('should handle fuzzy prefix searches', function() {
 		this.timeout(timeoutTime);
 		return wiki()
-			.prefixsearch('mic')
+			.prefixSearch('mic')
 			.then(titles =>
 				titles.should.have.property('results').containEql('Michael Jordan')
 			);

--- a/test/spec.js
+++ b/test/spec.js
@@ -114,7 +114,7 @@ describe('Wiki Methods', () => {
 			.reply(200, JSON.parse(fs.readFileSync('./test/data/prefixsearch.json')));
 
 		return wiki()
-			.prefixsearch('mic')
+			.prefixSearch('mic')
 			.should.eventually.have.property('results')
 			.containEql('Michael Jordan');
 	});

--- a/test/spec.js
+++ b/test/spec.js
@@ -97,6 +97,28 @@ describe('Wiki Methods', () => {
 		]);
 	});
 
+	it('Prefix search should find an article', () => {
+		nock('http://en.wikipedia.org')
+			.get('/w/api.php')
+			.query({
+				list: 'prefixsearch',
+				pssearch: 'mic',
+				pslimit: '50',
+				psprofile: 'fuzzy',
+				format: 'json',
+				action: 'query',
+				redirects: '',
+				origin: '*'
+			})
+			.once()
+			.reply(200, JSON.parse(fs.readFileSync('./test/data/prefixsearch.json')));
+
+		return wiki()
+			.prefixsearch('mic')
+			.should.eventually.have.property('results')
+			.containEql('Michael Jordan');
+	});
+
 	it('Search should limit properly', () => {
 		nock('http://en.wikipedia.org')
 			.get('/w/api.php')


### PR DESCRIPTION
Hello! 👋 This PR introduces the ability to perform "fuzzy" searching similar to the search functionality on the Wikipedia homepage. I was unable to reproduce this type of search via `Wiki#search` as fuzzy search explicitly requires setting the `list: 'prefixsearch'` and `psprofile: 'fuzzy'` params. 

*Also looks like prettier.js went through and tidied some things up. Let me know if this isn't preferred