### PR TITLE
Fixed interface Page

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -205,6 +205,14 @@ declare module 'wikijs' {
 		 * @memberof Page
 		 */
 		tables(): Promise<any>;
+
+		/**
+		 * Get URL for wiki page
+		 *
+		 * @return {URL}
+		 * @memberof Page
+		 */
+		url(): URL;
 	}
 
 	/**


### PR DESCRIPTION
```Page``` at index.d.ts doesn't have ```.url()``` method, so Lint can't correctly know it.    
This change will fix it based a description at [wikijs's document](https://dijs.github.io/wiki/WikiPage.html#url). Please confirm. :pray: