### PR TITLE
Implement Headers type in TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,13 @@ declare module 'wikijs' {
 		 * @memberof Options
 		 */
 		origin?: string;
+		/**
+		 * The Headers sent to be sent along with the request 
+		 *
+		 * @type {HeadersInit}
+		 * @memberof Options
+		 */
+		headers: HeadersInit;
 	}
 
 	/**


### PR DESCRIPTION
Usage of headers was documented in the readme but not included in the TypeScript definitions. This fixes that.

As a work around I added this locally to my project for testing.
```ts
declare module 'wikijs' {
  /**
   * The Headers sent to be sent along with the request
   *
   * @type {HeadersInit}
   * @memberof Options
   */
  interface Options {
    headers: HeadersInit;
  }
}
```