### PR TITLE
Added Page#rawContent to definitions (#153)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -195,6 +195,14 @@ declare module 'wikijs' {
 		mainImage(): Promise<string>;
 
 		/**
+		 * Raw content from page
+		 * 
+		 * @returns {Promise<string>}
+		 * @memberof Page
+		 */
+		rawContent(): Promise<string>;
+
+		/**
 		 * Raw data from images from page
 		 *
 		 * @returns {Promise<Image[]>}
@@ -340,11 +348,11 @@ declare module 'wikijs' {
 		 */
 		mostViewed(): Promise<{ title: string; count: number }[]>;
 
-	  /**
-		 * Fetch all page titles in wiki
-		 * @method Wiki#allPages
-		 * @return {Promise<string[]>} Array of pages
-		 */
+		/**
+		   * Fetch all page titles in wiki
+		   * @method Wiki#allPages
+		   * @return {Promise<string[]>} Array of pages
+		   */
 		allPages(): Promise<string[]>;
 
 		/**

--- a/test/real.js
+++ b/test/real.js
@@ -437,4 +437,15 @@ describe('Live tests', () => {
 				refs.length.should.equal(140);
 			});
 	});
+
+	it('should allow calling rawContent #153', () => {
+		this.timeout(timeoutTime);
+		return wiki()
+			.find('Alphabet')
+			.then(page => {
+				page.rawContent().then(rawContent => {
+					rawContent.length.should.equal(10);
+				})
+			});
+	});
 });


### PR DESCRIPTION
Adds `rawContent` under the `Page` interface in TypeScript definitions as it was missing.

Solves #153