### PR TITLE
use // in place of http to default to same protocal

### DIFF
--- a/src/wiki.js
+++ b/src/wiki.js
@@ -20,7 +20,7 @@ import QueryChain from './chain';
  * will be set.
  */
 const defaultOptions = {
-	apiUrl: 'http://en.wikipedia.org/w/api.php',
+	apiUrl: '//en.wikipedia.org/w/api.php',
 	origin: '*'
 };
 


### PR DESCRIPTION
I was experiencing an issue where my site, which uses `HTTPS`, was throwing an error because the default url for the API is `HTTP`. Updating this to use `//` will use the same protocol as the website your package is used on, which should fix this issue.