### PR TITLE
Getting rid of error 'refused to set unsafe header "user-agent"'

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -27,7 +27,7 @@ export function api(apiOptions, params = {}) {
 	}
 	const url = `${apiOptions.apiUrl}?${querystring.stringify(qs)}`;
 	const headers = Object.assign(
-		{ 'User-Agent': 'WikiJS Bot v1.0' },
+		{},
 		apiOptions.headers
 	);
 	return fetch(url, Object.assign({ headers }, fetchOptions))


### PR DESCRIPTION
Header` { 'User-Agent': 'WikiJS Bot v1.0' } ` is problematic, because some browsers throw this error when "User-agent" is used as an argument in function `xhr.setRequestHeader(name, value)` from cross-fetch module. I don't know if it's useful for something, so I'd be glad if someone could explain it to me.