### PR TITLE
support proxy through `https-proxy-agent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ wiki({
 }).search('Winterfell');
 ```
 
+## Usage with Proxy
+You can use proxy with `https-proxy-agent`
+```js
+const HttpsProxyAgent = require('https-proxy-agent')
+
+wiki({agent: new HttpsProxyAgent('http://address:port')})
+    .page('Batman')
+    .then(page => page.info('alterEgo'))
+    .then(console.log) // Bruce Wayne
+
+```
+
 ## Chain data requests together for more efficient applications
 
 Query a specific page:

--- a/src/util.js
+++ b/src/util.js
@@ -30,7 +30,7 @@ export function api(apiOptions, params = {}) {
 		{ 'User-Agent': 'WikiJS Bot v1.0' },
 		apiOptions.headers
 	);
-	return fetch(url, Object.assign({ headers }, fetchOptions))
+	return fetch(url, Object.assign({ headers }, fetchOptions, {agent: apiOptions.agent}))
 		.then(res => {
 			if (res.ok) {
 				return res.json();


### PR DESCRIPTION
Sometimes we may need to use behind proxy, I add this functionality by passing additional `agent` options to `fetch`. We can pass a agent object (from `https-proxy-agent`) when we call `wiki()`.