### PR TITLE
Do not emit declaration files

### DIFF
--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -3,7 +3,7 @@
       "allowJs": true,
       "allowSyntheticDefaultImports": true,
       "baseUrl": "src",
-      "declaration": true,
+      "declaration": false,
       "esModuleInterop": true,
       "inlineSourceMap": false,
       "lib": ["esnext"],


### PR DESCRIPTION
Declaration files are generated automatically and override the root declaration file `index.d.ts` which breaks TypeScript support as discussed in #178.

Generated declaration file:
![image](https://github.com/dijs/wiki/assets/480050/249f14f4-c197-4000-8284-4864c0908173)

Result when importing the library in an ESM project:
![image](https://github.com/dijs/wiki/assets/480050/f6c93da1-a246-4320-8f10-620a6bc4f1b8)

Disabling declaration files should let TypeScript rely on the root `index.d.ts` declarations that are up to date.
